### PR TITLE
Some suggestions..

### DIFF
--- a/flutter_todo/lib/components/todo_list.dart
+++ b/flutter_todo/lib/components/todo_list.dart
@@ -1,46 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter_todo/components/realm_provider.dart';
 import 'package:realm/realm.dart';
 import 'modify_todo.dart';
 import 'package:flutter_todo/realm/schemas.dart';
 
-class TodoList extends StatefulWidget {
-  TodoList({Key? key}) : super(key: key);
-
-  @override
-  State<TodoList> createState() => _TodoListState();
-}
-
-class _TodoListState extends State<TodoList> {
-  late RealmResults<Todo> _todos;
+class TodoList extends StatelessWidget {
+  const TodoList({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    // TODO: better to use Provider.of or Consumer?
-    final realmProvider = Provider.of<RealmProvider>(context);
-    final realm = realmProvider.realm;
-
-    if (mounted) {
-      setState(() {
-        _todos = realm.all<Todo>();
-      });
-    }
-
-    return SizedBox(
-      height: double.infinity,
-      // TODO: understand why this works and if there's a better way to do it.
-      child: StreamBuilder(
-          stream: _todos.changes,
-          builder: (context, snapshot) {
-            return ListView.builder(
-                itemCount: _todos.length,
-                itemBuilder: (_, i) {
-                  final todo = _todos[i];
-                  return _SingleTodoView(todo);
-                });
-          }),
-    );
+    final realm = Provider.of<Realm>(context);
+    final todos = realm.all<Todo>();
+    return StreamBuilder<RealmResultsChanges<Todo>>(
+        stream: todos.changes,
+        builder: (context, snapshot) {
+          final todos = snapshot.data?.results;
+          return ListView.builder(
+              itemCount: snapshot.data?.results.length ?? 0,
+              itemBuilder: (_, i) {
+                final todo = todos![i];
+                return _SingleTodoView(todo);
+              });
+        });
   }
 }
 
@@ -54,9 +35,7 @@ class _SingleTodoView extends StatelessWidget {
     return Card(
       child: ListTile(
         title: Text(todo.summary),
-        subtitle: todo.isComplete
-            ? const Text('Completed')
-            : const Text('Incomplete'),
+        subtitle: todo.isComplete ? const Text('Completed') : const Text('Incomplete'),
         trailing: ModifyTodoButton(todo),
       ),
     );

--- a/flutter_todo/lib/main.dart
+++ b/flutter_todo/lib/main.dart
@@ -1,46 +1,42 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_todo/components/realm_provider.dart';
+import 'package:flutter_todo/realm/schemas.dart';
 import 'package:provider/provider.dart';
+import 'package:realm/realm.dart';
 import 'components/todo_list.dart';
 import 'components/create_todo.dart';
-import 'components/realm_provider.dart';
 
-void main() async {
-  runApp(Provider<RealmProvider>(
-      create: (context) => RealmProvider(), child: const App()));
-}
+void main() => runApp(const App());
 
 class App extends StatelessWidget {
   const App({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Todo',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
+    return Provider<Realm>(
+      create: (_) => Realm(Configuration([Todo.schema])),
+      dispose: (_, r) => r.close(),
+      child: MaterialApp(
+        title: 'Flutter Todo',
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+        ),
+        home: const HomePage(title: 'Flutter Todo'),
       ),
-      home: const HomePage(title: 'Flutter Todo'),
     );
   }
 }
 
-class HomePage extends StatefulWidget {
+class HomePage extends StatelessWidget {
   const HomePage({Key? key, required this.title}) : super(key: key);
   final String title;
 
   @override
-  State<HomePage> createState() => _HomePageState();
-}
-
-class _HomePageState extends State<HomePage> {
-  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title),
+        title: Text(title),
       ),
-      body: TodoList(),
+      body: const TodoList(),
       floatingActionButton: const CreateTodo(),
     );
   }


### PR DESCRIPTION
I have simplified stuff a bit.

The Provider can just as well provide the Realm directly, so I got rid of `RealmProvider` class.

Regarding Consumer vs Provider.of. The first thing to notice is just that the former is simple wrapper around the later. I typically use Provider.of. In some cases you need to do the same trick as Consumer, ie. wrap the child in a Builder, but you don't really gain much by using Consumer over Provider.of + Builder.

I think the bottom sheet modification dialog is a bit odd. I would probably just have completed be a toggle on the list tile, and delete be a swipe action. 

One thing I miss, is an AnimatedList instead of a ListView. We have all the nitty gritty details in the changes stream to make it work. As is, we simply redraw the visible list tiles, whenever a change happens to the `realm.all<Todo>()` query result set. 

Anyway, I hope this is helpful.